### PR TITLE
fix basename on windows

### DIFF
--- a/gitsvnhelpers/utils.py
+++ b/gitsvnhelpers/utils.py
@@ -11,7 +11,7 @@ import config
 
 
 def basename():
-    return popen('basename $PWD', False, False)[1][0]
+    return os.path.basename(os.getcwd())
 
 
 def is_git():


### PR DESCRIPTION
By using the functions from the os package we keep the code portable.
Fixes issue #9
